### PR TITLE
Fix copy+paste typo

### DIFF
--- a/docs/schemas.md
+++ b/docs/schemas.md
@@ -105,7 +105,7 @@ print(dict(album))
 Index lookup on schema instances returns serialized datatypes.
 
 ```python
-print(type(album.release_date))
+print(type(album['release_date']))
 # <class 'str'>
 ```
 


### PR DESCRIPTION
Changes `print(type(album.release_date))` into `print(type(album['release_date']))` when describing index lookups.