### PR TITLE
Hide value for Password fields.

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -17,6 +17,7 @@ TypeSystem is a comprehensive data validation library that gives you:
 * Data validation.
 * Object serialization & deserialization.
 * Form rendering.
+* Tokenizing JSON or YAML to provide positional error messages.
 * 100% type annotated codebase.
 * 100% test coverage.
 * Zero hard dependencies.

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -8,7 +8,7 @@ class Contact(typesystem.Schema):
     b = typesystem.String(max_length=10)
     c = typesystem.Text()
     d = typesystem.Choice(choices=[("abc", "Abc"), ("def", "Def"), ("ghi", "Ghi")])
-    e = typesystem.String(format="password")
+
 
 forms = typesystem.Jinja2Forms(package="typesystem")
 
@@ -20,10 +20,17 @@ def test_form_rendering():
 
     assert html.count('<input type="checkbox" ') == 1
     assert html.count('<input type="text" ') == 1
-    assert html.count('<input type="password"') == 1
-    assert html.count('required value="">') == 1
     assert html.count("<textarea ") == 1
     assert html.count("<select ") == 1
+
+
+def test_password_rendering():
+    class PasswordForm(typesystem.Schema):
+        password = typesystem.String(format="password")
+
+    form = forms.Form(PasswordForm, values={"password": "secret"})
+    html = str(form)
+    assert "secret" not in html
 
 
 def test_form_html():

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -8,7 +8,7 @@ class Contact(typesystem.Schema):
     b = typesystem.String(max_length=10)
     c = typesystem.Text()
     d = typesystem.Choice(choices=[("abc", "Abc"), ("def", "Def"), ("ghi", "Ghi")])
-
+    e = typesystem.String(format="password")
 
 forms = typesystem.Jinja2Forms(package="typesystem")
 
@@ -20,6 +20,8 @@ def test_form_rendering():
 
     assert html.count('<input type="checkbox" ') == 1
     assert html.count('<input type="text" ') == 1
+    assert html.count('<input type="password"') == 1
+    assert html.count('required value="">') == 1
     assert html.count("<textarea ") == 1
     assert html.count("<select ") == 1
 

--- a/typesystem/forms.py
+++ b/typesystem/forms.py
@@ -69,6 +69,7 @@ class Form:
         input_type = self.input_type_for_field(field)
         template_name = self.template_for_field(field)
         template = self.env.get_template(template_name)
+        value = "" if input_type == "password" else value
         return template.render(
             {
                 "field_id": field_id,


### PR DESCRIPTION
Since the input field has this format:
```
<input type="password" id="form-contact-e" name="e" required value="">
```

I added two tests, one for the beginning of the string and one for the end, to get both type and value. How would you feel about moving the `value` tag to the front of the input so this can be consolidated into one test? This will also make it less brittle against other fields with empty string values.

Closes #30