### PR TITLE
Support compiled regular expressions as a pattern for string fields

### DIFF
--- a/docs/fields.md
+++ b/docs/fields.md
@@ -58,7 +58,7 @@ For example: `username = typesystem.String(max_length=100)`
 * `trim_whitespace` - A boolean indicating if leading/trailing whitespace should be removed on validation. **Default: `True`**
 * `max_length` - A maximum number of characters that valid input stings may contain. **Default: `None`**
 * `min_length` - A minimum number of characters that valid input stings may contain. **Default: `None`**
-* `pattern` - A string to be used as a regex that must match. Eg. `patern="^[A-Za-z]+$"` **Default: `None`**
+* `pattern` - A regular expression that must match. This can be either a string or a compiled regular expression object (which can have flags). E.g. `pattern="^[A-Za-z]+$"` **Default: `None`**
 * `format` - A string used to indicate a semantic type, such as `"email"`, `"url"`, or `"color"`. **Default: `None`**
 
 ### Text
@@ -97,8 +97,8 @@ provide more precise behaviour.
 * `maximum` - A number representing the maximum allowed value. Inputs must be less than or equal to this to validate. **Default: `None`**
 * `exclusive_minimum` - A number representing an exclusive minimum. Inputs must be greater than this to validate. **Default: `None`**
 * `exclusive_maximum` - A number representing an exclusive maximum. Inputs must be less than this to validate. **Default: `None`**
-* `precision` - A string representing the decimal precision to truncate input with. Eg. `precision="0.001"`. **Default: `None`**
-* `multiple_of` - A number giving a value that inputs must be a strict multiple of in order to validate. Eg. `multiple_of=2` will only validate even integers. **Default: `None`**
+* `precision` - A string representing the decimal precision to truncate input with. E.g. `precision="0.001"`. **Default: `None`**
+* `multiple_of` - A number giving a value that inputs must be a strict multiple of in order to validate. E.g. `multiple_of=2` will only validate even integers. **Default: `None`**
 
 ### Integer
 

--- a/docs/fields.md
+++ b/docs/fields.md
@@ -58,7 +58,7 @@ For example: `username = typesystem.String(max_length=100)`
 * `trim_whitespace` - A boolean indicating if leading/trailing whitespace should be removed on validation. **Default: `True`**
 * `max_length` - A maximum number of characters that valid input stings may contain. **Default: `None`**
 * `min_length` - A minimum number of characters that valid input stings may contain. **Default: `None`**
-* `pattern` - A regular expression that must match. This can be either a string or a compiled regular expression object (which can have flags). E.g. `pattern="^[A-Za-z]+$"` **Default: `None`**
+* `pattern` - A regular expression that must match. This can be either a string or a compiled regular expression. E.g. `pattern="^[A-Za-z]+$"` **Default: `None`**
 * `format` - A string used to indicate a semantic type, such as `"email"`, `"url"`, or `"color"`. **Default: `None`**
 
 ### Text

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,5 +1,6 @@
 import datetime
 import decimal
+import re
 
 from typesystem.base import Message, ValidationError
 from typesystem.fields import (
@@ -87,6 +88,10 @@ def test_string():
     assert error == ValidationError(
         text="Must match the pattern /^[abc]*$/.", code="pattern"
     )
+
+    validator = String(pattern=re.compile("ABC", re.IGNORECASE))
+    value, error = validator.validate_or_error("abc")
+    assert value == "abc"
 
     validator = String()
     value, error = validator.validate_or_error(" ")

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 
 import pytest
 
@@ -144,3 +145,15 @@ def test_to_json_schema_invalid_field():
     field = CustomField()
     with pytest.raises(TypeError):
         to_json_schema(field)
+
+
+def test_to_json_schema_complex_regular_expression():
+    field = typesystem.String(pattern=re.compile("foo", re.IGNORECASE | re.VERBOSE))
+    with pytest.raises(ValueError) as exc_info:
+        to_json_schema(field)
+
+    expected = (
+        "Cannot convert regular expression with non-standard flags "
+        "to JSON schema: RegexFlag."
+    )
+    assert str(exc_info.value).startswith(expected)

--- a/typesystem/fields.py
+++ b/typesystem/fields.py
@@ -78,6 +78,25 @@ class Field:
         return self.errors[code].format(**self.__dict__)
 
 
+def normalize_regex(
+    pattern: typing.Union[str, typing.Pattern] = None
+) -> typing.Tuple[typing.Optional[str], typing.Optional[typing.Pattern]]:
+    """
+    Normalise and validate a regular expression-like input.
+
+    Returns a 2-tuple with a pattern string and a compiled regular expression.
+    """
+    if pattern is None:
+        return (None, None)
+
+    if isinstance(pattern, str):
+        pattern_regex = re.compile(pattern)
+    else:
+        pattern_regex = pattern
+
+    return pattern_regex.pattern, pattern_regex
+
+
 class String(Field):
     errors = {
         "type": "Must be a string.",
@@ -110,20 +129,11 @@ class String(Field):
         if allow_blank and not self.has_default():
             self.default = ""
 
-        if pattern is None:
-            pattern_regex = None
-        elif isinstance(pattern, str):
-            pattern_regex = re.compile(pattern)
-        elif isinstance(pattern, typing.Pattern):
-            pattern_regex = pattern
-            pattern = pattern_regex.pattern
-
         self.allow_blank = allow_blank
         self.trim_whitespace = trim_whitespace
         self.max_length = max_length
         self.min_length = min_length
-        self.pattern = pattern
-        self.pattern_regex = pattern_regex
+        self.pattern, self.pattern_regex = normalize_regex(pattern)
         self.format = format
 
     def validate(self, value: typing.Any, *, strict: bool = False) -> typing.Any:

--- a/typesystem/fields.py
+++ b/typesystem/fields.py
@@ -85,7 +85,7 @@ class String(Field):
         "blank": "Must not be blank.",
         "max_length": "Must have no more than {max_length} characters.",
         "min_length": "Must have at least {min_length} characters.",
-        "pattern": "Must match the pattern /{pattern}/.",
+        "pattern": "Must match the pattern /{pattern.pattern}/.",
         "format": "Must be a valid {format}.",
     }
 
@@ -96,7 +96,7 @@ class String(Field):
         trim_whitespace: bool = True,
         max_length: int = None,
         min_length: int = None,
-        pattern: str = None,
+        pattern: typing.Union[str, typing.Pattern] = None,
         format: str = None,
         **kwargs: typing.Any,
     ) -> None:
@@ -104,11 +104,14 @@ class String(Field):
 
         assert max_length is None or isinstance(max_length, int)
         assert min_length is None or isinstance(min_length, int)
-        assert pattern is None or isinstance(pattern, str)
+        assert pattern is None or isinstance(pattern, (str, typing.Pattern))
         assert format is None or isinstance(format, str)
 
         if allow_blank and not self.has_default():
             self.default = ""
+
+        if isinstance(pattern, str):
+            pattern = re.compile(pattern)
 
         self.allow_blank = allow_blank
         self.trim_whitespace = trim_whitespace
@@ -152,7 +155,7 @@ class String(Field):
                 raise self.validation_error("max_length")
 
         if self.pattern is not None:
-            if not re.search(self.pattern, value):
+            if not self.pattern.search(value):
                 raise self.validation_error("pattern")
 
         if self.format in FORMATS:

--- a/typesystem/json_schema.py
+++ b/typesystem/json_schema.py
@@ -321,9 +321,10 @@ def to_json_schema(
             data["maxLength"] = field.max_length
         if field.pattern_regex is not None:
             if field.pattern_regex.flags != re.RegexFlag.UNICODE:
+                flags = re.RegexFlag(field.pattern_regex.flags)
                 raise ValueError(
                     f"Cannot convert regular expression with non-standard flags "
-                    f"to JSON schema: {re.RegexFlag(field.pattern_regex.flags)!s}"
+                    f"to JSON schema: {flags!s}"
                 )
             data["pattern"] = field.pattern_regex.pattern
         if field.format is not None:

--- a/typesystem/json_schema.py
+++ b/typesystem/json_schema.py
@@ -1,3 +1,4 @@
+import re
 import typing
 
 from typesystem.composites import AllOf, IfThenElse, NeverMatch, Not, OneOf
@@ -319,7 +320,12 @@ def to_json_schema(
         if field.max_length is not None:
             data["maxLength"] = field.max_length
         if field.pattern is not None:
-            data["pattern"] = field.pattern
+            if field.pattern.flags != re.RegexFlag.UNICODE:
+                raise ValueError(
+                    f"Cannot convert regular expression with non-standard flags "
+                    f"to JSON schema: {re.RegexFlag(field.pattern.flags)!s}"
+                )
+            data["pattern"] = field.pattern.pattern
         if field.format is not None:
             data["format"] = field.format
         return data

--- a/typesystem/json_schema.py
+++ b/typesystem/json_schema.py
@@ -319,13 +319,13 @@ def to_json_schema(
             data["minLength"] = field.min_length or 1
         if field.max_length is not None:
             data["maxLength"] = field.max_length
-        if field.pattern is not None:
-            if field.pattern.flags != re.RegexFlag.UNICODE:
+        if field.pattern_regex is not None:
+            if field.pattern_regex.flags != re.RegexFlag.UNICODE:
                 raise ValueError(
                     f"Cannot convert regular expression with non-standard flags "
-                    f"to JSON schema: {re.RegexFlag(field.pattern.flags)!s}"
+                    f"to JSON schema: {re.RegexFlag(field.pattern_regex.flags)!s}"
                 )
-            data["pattern"] = field.pattern.pattern
+            data["pattern"] = field.pattern_regex.pattern
         if field.format is not None:
             data["format"] = field.format
         return data


### PR DESCRIPTION
This changes the ‘pattern’ argument for string fields in such a way
that compiled regular expressions can be passed as well. This is
useful for specifying flags, such as ‘re.IGNORECASE’.

Internally, a pattern is always stored as compiled regular expression.
The benefits here are that the regular expression is only compiled
once, and that the regular expression itself is syntactically
validated upon field creation, instead of at first use during
validation.

This change also adapts the error messages to print the pattern in a
nice way. Customisation for this is out of scope; see #28.

Updated the docs to reflect the above changes; changed a few typos
while at it.

Closes #42.