### PR TITLE
Improve error handing when JSON schema conversion fails

### DIFF
--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -142,5 +142,9 @@ def test_to_json_schema_invalid_field():
         pass
 
     field = CustomField()
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError) as exc_info:
         to_json_schema(field)
+
+    message = str(exc_info.value)
+    assert message.startswith("Unsupported field type")
+    assert "CustomField" in message

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -137,14 +137,14 @@ def test_schema_to_json_schema():
     }
 
 
-def test_to_json_schema_invalid_field():
-    class CustomField(typesystem.Field):
-        pass
+class CustomField(typesystem.Field):
+    pass
 
+
+def test_to_json_schema_invalid_field():
     field = CustomField()
-    with pytest.raises(TypeError) as exc_info:
+    with pytest.raises(ValueError) as exc_info:
         to_json_schema(field)
 
-    message = str(exc_info.value)
-    assert message.startswith("Unsupported field type")
-    assert "CustomField" in message
+    expected = "Cannot convert field type 'CustomField' to JSON Schema"
+    assert str(exc_info.value) == expected

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -150,6 +150,7 @@ def test_to_json_schema_invalid_field():
     expected = "Cannot convert field type 'CustomField' to JSON Schema"
     assert str(exc_info.value) == expected
 
+
 def test_to_json_schema_complex_regular_expression():
     field = typesystem.String(pattern=re.compile("foo", re.IGNORECASE | re.VERBOSE))
     with pytest.raises(ValueError) as exc_info:

--- a/typesystem/json_schema.py
+++ b/typesystem/json_schema.py
@@ -435,7 +435,9 @@ def to_json_schema(
         return data
 
     field_type = type(field)
-    raise TypeError("Unsupported field type {field_type} passed to 'to_json_schema'")
+    raise TypeError(
+        f"Unsupported field type {field_type.__qualname__!r} passed to 'to_json_schema'"
+    )
 
 
 def get_standard_properties(field: Field) -> dict:

--- a/typesystem/json_schema.py
+++ b/typesystem/json_schema.py
@@ -434,10 +434,8 @@ def to_json_schema(
         data.update(get_standard_properties(field))
         return data
 
-    field_type = type(field)
-    raise TypeError(
-        f"Unsupported field type {field_type.__qualname__!r} passed to 'to_json_schema'"
-    )
+    name = type(field).__qualname__
+    raise ValueError(f"Cannot convert field type {name!r} to JSON Schema")
 
 
 def get_standard_properties(field: Field) -> dict:


### PR DESCRIPTION
Use a template, improve the error message, and add tests.