### PR TITLE
Use Python syntax for type hints instead of comments

### DIFF
--- a/typesystem/base.py
+++ b/typesystem/base.py
@@ -138,9 +138,9 @@ class BaseError(Mapping, Exception):
             assert len(messages)
 
         self._messages = messages
-        self._message_dict = (
-            {}
-        )  # type: typing.Dict[typing.Any, typing.Union[str, dict]]
+        self._message_dict: typing.Dict[
+            typing.Union[int, str], typing.Union[str, dict]
+        ] = {}
 
         # Populate 'self._message_dict'
         for message in messages:

--- a/typesystem/fields.py
+++ b/typesystem/fields.py
@@ -17,7 +17,7 @@ FORMATS = {
 
 
 class Field:
-    errors = {}  # type: typing.Dict[str, str]
+    errors: typing.Dict[str, str] = {}
     _creation_counter = 0
 
     def __init__(
@@ -189,7 +189,7 @@ class String(Field):
 
 
 class Number(Field):
-    numeric_type = None  # type: type
+    numeric_type: typing.Optional[type] = None
     errors = {
         "type": "Must be a number.",
         "null": "May not be null.",
@@ -621,7 +621,7 @@ class Array(Field):
 
         # Ensure all items are of the right type.
         validated = []
-        error_messages = []  # type: typing.List[Message]
+        error_messages: typing.List[Message] = []
         if self.unique_items:
             seen_items = Uniqueness()
 

--- a/typesystem/formats.py
+++ b/typesystem/formats.py
@@ -20,7 +20,7 @@ DATETIME_REGEX = re.compile(
 
 
 class BaseFormat:
-    errors = {}  # type: typing.Dict[str, str]
+    errors: typing.Dict[str, str] = {}
 
     def validation_error(self, code: str) -> ValidationError:
         text = self.errors[code].format(**self.__dict__)
@@ -80,7 +80,7 @@ class TimeFormat(BaseFormat):
 
         kwargs = {k: int(v) for k, v in groups.items() if v is not None}
         try:
-            return datetime.time(**kwargs, tzinfo=None)  # type: ignore
+            return datetime.time(tzinfo=None, **kwargs)
         except ValueError:
             raise self.validation_error("invalid")
 

--- a/typesystem/forms.py
+++ b/typesystem/forms.py
@@ -121,7 +121,7 @@ class Jinja2Forms:
         self, *, directory: str = None, package: str = None
     ) -> "jinja2.Environment":
         if directory is not None and package is None:
-            loader = jinja2.FileSystemLoader(directory)  # type: jinja2.BaseLoader
+            loader: jinja2.BaseLoader = jinja2.FileSystemLoader(directory)
         elif directory is None and package is not None:
             loader = jinja2.PackageLoader(package, "templates")
         else:

--- a/typesystem/json_schema.py
+++ b/typesystem/json_schema.py
@@ -247,7 +247,7 @@ def from_json_schema_type(
     elif type_string == "array":
         items = data.get("items", None)
         if items is None:
-            items_argument = None  # type: typing.Union[None, Field, typing.List[Field]]
+            items_argument: typing.Union[None, Field, typing.List[Field]] = None
         elif isinstance(items, list):
             items_argument = [
                 from_json_schema(item, definitions=definitions) for item in items
@@ -257,7 +257,7 @@ def from_json_schema_type(
 
         additional_items = data.get("additionalItems", None)
         if additional_items is None:
-            additional_items_argument = True  # type: typing.Union[bool, Field]
+            additional_items_argument: typing.Union[bool, Field] = True
         elif isinstance(additional_items, bool):
             additional_items_argument = additional_items
         else:
@@ -279,7 +279,7 @@ def from_json_schema_type(
     elif type_string == "object":
         properties = data.get("properties", None)
         if properties is None:
-            properties_argument = None  # type: typing.Optional[typing.Dict[str, Field]]
+            properties_argument: typing.Optional[typing.Dict[str, Field]] = None
         else:
             properties_argument = {
                 key: from_json_schema(value, definitions=definitions)
@@ -288,9 +288,9 @@ def from_json_schema_type(
 
         pattern_properties = data.get("patternProperties", None)
         if pattern_properties is None:
-            pattern_properties_argument = (
+            pattern_properties_argument: typing.Optional[typing.Dict[str, Field]] = (
                 None
-            )  # type: typing.Optional[typing.Dict[str, Field]]
+            )
         else:
             pattern_properties_argument = {
                 key: from_json_schema(value, definitions=definitions)
@@ -299,9 +299,7 @@ def from_json_schema_type(
 
         additional_properties = data.get("additionalProperties", None)
         if additional_properties is None:
-            additional_properties_argument = (
-                None
-            )  # type: typing.Union[None, bool, Field]
+            additional_properties_argument: typing.Union[None, bool, Field] = (None)
         elif isinstance(additional_properties, bool):
             additional_properties_argument = additional_properties
         else:
@@ -311,7 +309,7 @@ def from_json_schema_type(
 
         property_names = data.get("propertyNames", None)
         if property_names is None:
-            property_names_argument = None  # type: typing.Optional[Field]
+            property_names_argument: typing.Optional[Field] = None
         else:
             property_names_argument = from_json_schema(
                 property_names, definitions=definitions
@@ -405,7 +403,7 @@ def to_json_schema(
     elif isinstance(arg, NeverMatch):
         return False
 
-    data = {}  # type: dict
+    data: dict = {}
     is_root = _definitions is None
     definitions = {} if _definitions is None else _definitions
 

--- a/typesystem/schemas.py
+++ b/typesystem/schemas.py
@@ -56,7 +56,7 @@ class SchemaMetaclass(ABCMeta):
         attrs: dict,
         definitions: SchemaDefinitions = None,
     ) -> type:
-        fields = {}  # type: typing.Dict[str, Field]
+        fields: typing.Dict[str, Field] = {}
 
         for key, value in list(attrs.items()):
             if isinstance(value, Field):
@@ -90,7 +90,7 @@ class SchemaMetaclass(ABCMeta):
 
 
 class Schema(Mapping, metaclass=SchemaMetaclass):
-    fields = {}  # type: typing.Dict[str, Field]
+    fields: typing.Dict[str, Field] = {}
 
     def __init__(self, *args: typing.Any, **kwargs: typing.Any) -> None:
         if args:

--- a/typesystem/tokenize/tokenize_json.py
+++ b/typesystem/tokenize/tokenize_json.py
@@ -27,7 +27,7 @@ def _TokenizingJSONObject(
     _ws: str = WHITESPACE_STR,
 ) -> typing.Tuple[dict, int]:
     s, end = s_and_end
-    pairs = []  # type: typing.List[typing.Tuple[Token, Token]]
+    pairs: typing.List[typing.Tuple[Token, Token]] = []
     pairs_append = pairs.append
     memo_get = memo.setdefault
     # Use a slice to prevent IndexError from being raised, the following

--- a/typesystem/unique.py
+++ b/typesystem/unique.py
@@ -13,7 +13,7 @@ class Uniqueness:
     FALSE = object()
 
     def __init__(self, items: list = None) -> None:
-        self._set = set()  # type: set
+        self._set: set = set()
         for item in items or []:
             self.add(item)
 


### PR DESCRIPTION
This changes all type hints to use modern Python (3.6+) syntax instead
of special comments, but leaves the ‘type: ignore’ comments intact.

Most of these changes are purely mechanical, except for these:

- It seems the _message_dict can only ever contain str and int keys,
  so make that explicit instead of using `typing.Any`.

- The call to `datetime.time(**kwargs, tzinfo=None)` gives mypy
  warnings which can be avoided by reordering the arguments. Changing
  it to `datetime.time(tzinfo=None, **kwargs)` will behave the same,
  since `kwargs` will never contain a `tzinfo` key, because
  `TIME_REGEX` does not have a capturing group with that name.