### PR TITLE
Raise correct exception to indicate ‘not implemented’

### DIFF
--- a/typesystem/tokenize/tokens.py
+++ b/typesystem/tokenize/tokens.py
@@ -13,13 +13,13 @@ class Token:
         self._content = content
 
     def _get_value(self) -> typing.Any:
-        raise NotImplemented()  # pragma: nocover
+        raise NotImplementedError  # pragma: nocover
 
     def _get_child_token(self, key: typing.Any) -> "Token":
-        raise NotImplemented()  # pragma: nocover
+        raise NotImplementedError  # pragma: nocover
 
     def _get_key_token(self, key: typing.Any) -> "Token":
-        raise NotImplemented()  # pragma: nocover
+        raise NotImplementedError  # pragma: nocover
 
     @property
     def string(self) -> str:


### PR DESCRIPTION
The code incorrectly tries to raise `NotImplemented` in a few places,
which is a special value that is used as a return value in some
scenarios. It is not an exception type and cannot be raised:

```
>>> raise NotImplemented
...
TypeError: exceptions must derive from BaseException
```

The fix is to raise `NotImplementedError` instead.