### PR TITLE
Add explicit Python 3.6+ requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
     author_email='tom@tomchristie.com',
     packages=get_packages('typesystem'),
     install_requires=[],
+    python_requires='>=3.6',
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Intended Audience :: Developers',


### PR DESCRIPTION
This uses the pip 9+/setuptools 24.2+ [python_requires](https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires) setting to enforce a Python version above 3.6 to avoid strange errors. Python 3.5 mostly complains about f-strings.