### PR TITLE
Add type marker for PEP 561

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(
     author='Tom Christie',
     author_email='tom@tomchristie.com',
     packages=get_packages('typesystem'),
+    package_data={'typesystem': ['py.typed']},
     install_requires=[],
     python_requires='>=3.6',
     classifiers=[
@@ -50,5 +51,6 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
-    ]
+    ],
+    zip_safe=False
 )


### PR DESCRIPTION
This indicates to type checker tools that `typesystem` has inline type hints.

Mypy is unable to tell otherwise, and errors, e.g:

```
inv/asset.py:3: error: Cannot find module named 'typesystem'
inv/asset.py:3: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
inv/asset.py:6: error: Class cannot subclass 'Schema' (has type 'Any')
inv/asset.py:6: error: Base type Schema becomes "Any" due to an unfollowed import
inv/asset.py:14: error: Expression has type "Any"
inv/asset.py:15: error: Expression has type "Any"
inv/asset.py:16: error: Expression has type "Any"
make: *** [Makefile:12: type] Error 1
```

More information on this can be found at https://www.python.org/dev/peps/pep-0561/#id18