### PR TITLE
Fix typo in requirements

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -62,7 +62,7 @@ Using typesystem for a simple Web submission page.
 
 ```
 aiofiles          # Static files support
-boostrap4         # Form templates & static files
+bootstrap4         # Form templates & static files
 jinja2            # Form rendering
 python-multipart  # Form parsing
 starlette


### PR DESCRIPTION
Currently, using this requirements will fail as `boostrap4` doesn't exist as python package.