### PR TITLE
renamed format `datetime` to `date-time`

### DIFF
--- a/typesystem/fields.py
+++ b/typesystem/fields.py
@@ -12,7 +12,7 @@ NO_DEFAULT = object()
 FORMATS = {
     "date": formats.DateFormat(),
     "time": formats.TimeFormat(),
-    "datetime": formats.DateTimeFormat(),
+    "date-time": formats.DateTimeFormat(),
     "uuid": formats.UUIDFormat(),
 }
 
@@ -691,7 +691,7 @@ class Time(String):
 
 class DateTime(String):
     def __init__(self, **kwargs: typing.Any) -> None:
-        super().__init__(format="datetime", **kwargs)
+        super().__init__(format="date-time", **kwargs)
 
 
 class Union(Field):

--- a/typesystem/forms.py
+++ b/typesystem/forms.py
@@ -14,7 +14,7 @@ class Form:
     # Does not include "checkbox", "radio", "file", "image", "reset", "submit", "button"
     FORMAT_TO_INPUTTYPE = {
         "color": "color",
-        "datetime": "datetime-local",
+        "date-time": "datetime-local",
         "date": "date",
         "email": "email",
         "hidden": "hidden",


### PR DESCRIPTION
as per JSON schema specification (and also OpenAPI specification), see, e.g., https://json-schema.org/understanding-json-schema/reference/string.html#dates-and-times