### PR TITLE
fix json schema test

### DIFF
--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -166,7 +166,6 @@ def test_to_json_schema_complex_regular_expression():
         to_json_schema(field)
 
     expected = (
-        "Cannot convert regular expression with non-standard flags "
-        "to JSON schema: re.IGNORECASE|re.UNICODE|re.VERBOSE"
+        "Cannot convert regular expression with non-standard flags " "to JSON schema: "
     )
     assert str(exc_info.value).startswith(expected)

--- a/tests/test_json_schema.py
+++ b/tests/test_json_schema.py
@@ -166,6 +166,6 @@ def test_to_json_schema_complex_regular_expression():
         to_json_schema(field)
 
     expected = (
-        "Cannot convert regular expression with non-standard flags " "to JSON schema: "
+        "Cannot convert regular expression with non-standard flags to JSON schema: "
     )
     assert str(exc_info.value).startswith(expected)

--- a/typesystem/schemas.py
+++ b/typesystem/schemas.py
@@ -75,7 +75,7 @@ class SchemaMetaclass(ABCMeta):
             for field in fields.values():
                 set_definitions(field, definitions)
 
-        #  Sort fields by their actual position in the source code,
+        # Sort fields by their actual position in the source code,
         # using `Field._creation_counter`
         attrs["fields"] = dict(
             sorted(fields.items(), key=lambda item: item[1]._creation_counter)


### PR DESCRIPTION
The regex ValueError exception has changed after python3.7.

Of course we can test both 3.7 and 3.8 exception but I didn't see the point any way.