### PR TITLE
Fix broken reference in OAS 3

### DIFF
--- a/docs/json_schema.md
+++ b/docs/json_schema.md
@@ -7,7 +7,7 @@ TypeSystem can convert Schema or Field instances to/from JSON Schema.
     All references should be of the style `{"$ref": "#/components/schemas/..."}`.
 
     Using hyperlinked references, relative references, or references to parts
-    of the document other than "definitions" is not supported.
+    of the document other than "components/schemas" is not supported.
 
 Let's define a schema, and dump it out into a JSON schema document:
 

--- a/docs/references.md
+++ b/docs/references.md
@@ -53,42 +53,44 @@ definitions["Album"] = album_schema
 document = typesystem.to_json_schema(definitions)
 print(json.dumps(document, indent=4))
 # {
-#     "definitions": {
-#         "Artist": {
-#             "type": "object",
-#             "properties": {
-#                 "name": {
-#                     "type": "string",
-#                     "minLength": 1,
-#                     "maxLength": 100
-#                 }
-#             },
-#             "required": [
-#                 "name"
-#             ]
-#         },
-#         "Album": {
-#             "type": "object",
-#             "properties": {
-#                 "title": {
-#                     "type": "string",
-#                     "minLength": 1,
-#                     "maxLength": 100
+#     "components":{
+#         "schemas":{
+#             "Artist":{
+#                 "type":"object",
+#                 "properties":{
+#                     "name":{
+#                         "type":"string",
+#                         "minLength":1,
+#                         "maxLength":100
+#                     }
 #                 },
-#                 "release_date": {
-#                     "type": "string",
-#                     "minLength": 1,
-#                     "format": "date"
-#                 },
-#                 "artist": {
-#                     "$ref": "#/definitions/Artist"
-#                 }
+#                 "required":[
+#                     "name"
+#                 ]
 #             },
-#             "required": [
-#                 "title",
-#                 "release_date",
-#                 "artist"
-#             ]
+#             "Album":{
+#                 "type":"object",
+#                 "properties":{
+#                     "title":{
+#                         "type":"string",
+#                         "minLength":1,
+#                         "maxLength":100
+#                     },
+#                     "release_date":{
+#                         "type":"string",
+#                         "minLength":1,
+#                         "format":"date"
+#                     },
+#                     "artist":{
+#                         "$ref":"#/components/schemas/Artist"
+#                     }
+#                 },
+#                 "required":[
+#                     "title",
+#                     "release_date",
+#                     "artist"
+#                 ]
+#             }
 #         }
 #     }
 # }

--- a/tests/jsonschema/draft7/definitions.json
+++ b/tests/jsonschema/draft7/definitions.json
@@ -1,13 +1,19 @@
 [
     {
         "description": "valid definition",
-        "schema": {"$ref": "http://json-schema.org/draft-07/schema#"},
+        "schema": {
+            "$ref": "http://json-schema.org/draft-07/schema#"
+        },
         "tests": [
             {
                 "description": "valid definition schema",
                 "data": {
-                    "definitions": {
-                        "foo": {"type": "integer"}
+                    "components": {
+                        "schemas": {
+                            "foo": {
+                                "type": "integer"
+                            }
+                        }
                     }
                 },
                 "valid": true
@@ -16,13 +22,19 @@
     },
     {
         "description": "invalid definition",
-        "schema": {"$ref": "http://json-schema.org/draft-07/schema#"},
+        "schema": {
+            "$ref": "http://json-schema.org/draft-07/schema#"
+        },
         "tests": [
             {
                 "description": "invalid definition schema",
                 "data": {
-                    "definitions": {
-                        "foo": {"type": 1}
+                    "components": {
+                        "schemas": {
+                            "foo": {
+                                "type": 1
+                            }
+                        }
                     }
                 },
                 "valid": false

--- a/tests/jsonschema/draft7/definitionsRef.json
+++ b/tests/jsonschema/draft7/definitionsRef.json
@@ -2,10 +2,18 @@
     {
         "description": "nested refs",
         "schema": {
-            "definitions": {
-                "a": {"type": "integer"},
-                "b": {"$ref": "#/components/schemas/a"},
-                "c": {"$ref": "#/components/schemas/b"}
+            "components": {
+                "schemas": {
+                    "a": {
+                        "type": "integer"
+                    },
+                    "b": {
+                        "$ref": "#/components/schemas/a"
+                    },
+                    "c": {
+                        "$ref": "#/components/schemas/b"
+                    }
+                }
             },
             "$ref": "#/components/schemas/c"
         },
@@ -25,9 +33,11 @@
     {
         "description": "ref overrides any sibling keywords",
         "schema": {
-            "definitions": {
-                "reffed": {
-                    "type": "array"
+            "components": {
+                "schemas": {
+                    "reffed": {
+                        "type": "array"
+                    }
                 }
             },
             "properties": {
@@ -40,17 +50,27 @@
         "tests": [
             {
                 "description": "ref valid",
-                "data": { "foo": [] },
+                "data": {
+                    "foo": []
+                },
                 "valid": true
             },
             {
                 "description": "ref valid, maxItems ignored",
-                "data": { "foo": [ 1, 2, 3] },
+                "data": {
+                    "foo": [
+                        1,
+                        2,
+                        3
+                    ]
+                },
                 "valid": true
             },
             {
                 "description": "ref invalid",
-                "data": { "foo": "string" },
+                "data": {
+                    "foo": "string"
+                },
                 "valid": false
             }
         ]
@@ -59,8 +79,10 @@
         "description": "$ref to boolean schema true",
         "schema": {
             "$ref": "#/components/schemas/bool",
-            "definitions": {
-                "bool": true
+            "components": {
+                "schemas": {
+                    "bool": true
+                }
             }
         },
         "tests": [
@@ -75,8 +97,10 @@
         "description": "$ref to boolean schema false",
         "schema": {
             "$ref": "#/components/schemas/bool",
-            "definitions": {
-                "bool": false
+            "components": {
+                "schemas": {
+                    "bool": false
+                }
             }
         },
         "tests": [

--- a/tests/jsonschema/draft7/ref.json
+++ b/tests/jsonschema/draft7/ref.json
@@ -3,29 +3,43 @@
         "description": "root pointer ref",
         "schema": {
             "properties": {
-                "foo": {"$ref": "#"}
+                "foo": {
+                    "$ref": "#"
+                }
             },
             "additionalProperties": false
         },
         "tests": [
             {
                 "description": "match",
-                "data": {"foo": false},
+                "data": {
+                    "foo": false
+                },
                 "valid": true
             },
             {
                 "description": "recursive match",
-                "data": {"foo": {"foo": false}},
+                "data": {
+                    "foo": {
+                        "foo": false
+                    }
+                },
                 "valid": true
             },
             {
                 "description": "mismatch",
-                "data": {"bar": false},
+                "data": {
+                    "bar": false
+                },
                 "valid": false
             },
             {
                 "description": "recursive mismatch",
-                "data": {"foo": {"bar": false}},
+                "data": {
+                    "foo": {
+                        "bar": false
+                    }
+                },
                 "valid": false
             }
         ]
@@ -34,19 +48,27 @@
         "description": "relative pointer ref to object",
         "schema": {
             "properties": {
-                "foo": {"type": "integer"},
-                "bar": {"$ref": "#/properties/foo"}
+                "foo": {
+                    "type": "integer"
+                },
+                "bar": {
+                    "$ref": "#/properties/foo"
+                }
             }
         },
         "tests": [
             {
                 "description": "match",
-                "data": {"bar": 3},
+                "data": {
+                    "bar": 3
+                },
                 "valid": true
             },
             {
                 "description": "mismatch",
-                "data": {"bar": true},
+                "data": {
+                    "bar": true
+                },
                 "valid": false
             }
         ]
@@ -55,19 +77,29 @@
         "description": "relative pointer ref to array",
         "schema": {
             "items": [
-                {"type": "integer"},
-                {"$ref": "#/items/0"}
+                {
+                    "type": "integer"
+                },
+                {
+                    "$ref": "#/items/0"
+                }
             ]
         },
         "tests": [
             {
                 "description": "match array",
-                "data": [1, 2],
+                "data": [
+                    1,
+                    2
+                ],
                 "valid": true
             },
             {
                 "description": "mismatch array",
-                "data": [1, "foo"],
+                "data": [
+                    1,
+                    "foo"
+                ],
                 "valid": false
             }
         ]
@@ -75,44 +107,68 @@
     {
         "description": "escaped pointer ref",
         "schema": {
-            "tilda~field": {"type": "integer"},
-            "slash/field": {"type": "integer"},
-            "percent%field": {"type": "integer"},
+            "tilda~field": {
+                "type": "integer"
+            },
+            "slash/field": {
+                "type": "integer"
+            },
+            "percent%field": {
+                "type": "integer"
+            },
             "properties": {
-                "tilda": {"$ref": "#/tilda~0field"},
-                "slash": {"$ref": "#/slash~1field"},
-                "percent": {"$ref": "#/percent%25field"}
+                "tilda": {
+                    "$ref": "#/tilda~0field"
+                },
+                "slash": {
+                    "$ref": "#/slash~1field"
+                },
+                "percent": {
+                    "$ref": "#/percent%25field"
+                }
             }
         },
         "tests": [
             {
                 "description": "slash invalid",
-                "data": {"slash": "aoeu"},
+                "data": {
+                    "slash": "aoeu"
+                },
                 "valid": false
             },
             {
                 "description": "tilda invalid",
-                "data": {"tilda": "aoeu"},
+                "data": {
+                    "tilda": "aoeu"
+                },
                 "valid": false
             },
             {
                 "description": "percent invalid",
-                "data": {"percent": "aoeu"},
+                "data": {
+                    "percent": "aoeu"
+                },
                 "valid": false
             },
             {
                 "description": "slash valid",
-                "data": {"slash": 123},
+                "data": {
+                    "slash": 123
+                },
                 "valid": true
             },
             {
                 "description": "tilda valid",
-                "data": {"tilda": 123},
+                "data": {
+                    "tilda": 123
+                },
                 "valid": true
             },
             {
                 "description": "percent valid",
-                "data": {"percent": 123},
+                "data": {
+                    "percent": 123
+                },
                 "valid": true
             }
         ]
@@ -120,12 +176,18 @@
     {
         "description": "nested refs",
         "schema": {
-            "definitions": {
-                "a": {"type": "integer"},
-                "b": {"$ref": "#/definitions/a"},
-                "c": {"$ref": "#/definitions/b"}
+            "components/schemas": {
+                "a": {
+                    "type": "integer"
+                },
+                "b": {
+                    "$ref": "#/components/schemas/a"
+                },
+                "c": {
+                    "$ref": "#/components/schemas/b"
+                }
             },
-            "$ref": "#/definitions/c"
+            "$ref": "#/components/schemas/c"
         },
         "tests": [
             {
@@ -143,14 +205,14 @@
     {
         "description": "ref overrides any sibling keywords",
         "schema": {
-            "definitions": {
+            "components/schemas": {
                 "reffed": {
                     "type": "array"
                 }
             },
             "properties": {
                 "foo": {
-                    "$ref": "#/definitions/reffed",
+                    "$ref": "#/components/schemas/reffed",
                     "maxItems": 2
                 }
             }
@@ -158,33 +220,49 @@
         "tests": [
             {
                 "description": "ref valid",
-                "data": { "foo": [] },
+                "data": {
+                    "foo": []
+                },
                 "valid": true
             },
             {
                 "description": "ref valid, maxItems ignored",
-                "data": { "foo": [ 1, 2, 3] },
+                "data": {
+                    "foo": [
+                        1,
+                        2,
+                        3
+                    ]
+                },
                 "valid": true
             },
             {
                 "description": "ref invalid",
-                "data": { "foo": "string" },
+                "data": {
+                    "foo": "string"
+                },
                 "valid": false
             }
         ]
     },
     {
         "description": "remote ref, containing refs itself",
-        "schema": {"$ref": "http://json-schema.org/draft-07/schema#"},
+        "schema": {
+            "$ref": "http://json-schema.org/draft-07/schema#"
+        },
         "tests": [
             {
                 "description": "remote ref valid",
-                "data": {"minLength": 1},
+                "data": {
+                    "minLength": 1
+                },
                 "valid": true
             },
             {
                 "description": "remote ref invalid",
-                "data": {"minLength": -1},
+                "data": {
+                    "minLength": -1
+                },
                 "valid": false
             }
         ]
@@ -193,18 +271,24 @@
         "description": "property named $ref that is not a reference",
         "schema": {
             "properties": {
-                "$ref": {"type": "string"}
+                "$ref": {
+                    "type": "string"
+                }
             }
         },
         "tests": [
             {
                 "description": "property named $ref valid",
-                "data": {"$ref": "a"},
+                "data": {
+                    "$ref": "a"
+                },
                 "valid": true
             },
             {
                 "description": "property named $ref invalid",
-                "data": {"$ref": 2},
+                "data": {
+                    "$ref": 2
+                },
                 "valid": false
             }
         ]
@@ -212,8 +296,8 @@
     {
         "description": "$ref to boolean schema true",
         "schema": {
-            "$ref": "#/definitions/bool",
-            "definitions": {
+            "$ref": "#/components/schemas/bool",
+            "components/schemas": {
                 "bool": true
             }
         },
@@ -228,8 +312,8 @@
     {
         "description": "$ref to boolean schema false",
         "schema": {
-            "$ref": "#/definitions/bool",
-            "definitions": {
+            "$ref": "#/components/schemas/bool",
+            "components/schemas": {
                 "bool": false
             }
         },
@@ -248,30 +332,43 @@
             "description": "tree of nodes",
             "type": "object",
             "properties": {
-                "meta": {"type": "string"},
+                "meta": {
+                    "type": "string"
+                },
                 "nodes": {
                     "type": "array",
-                    "items": {"$ref": "node"}
+                    "items": {
+                        "$ref": "node"
+                    }
                 }
             },
-            "required": ["meta", "nodes"],
-            "definitions": {
+            "required": [
+                "meta",
+                "nodes"
+            ],
+            "components/schemas": {
                 "node": {
                     "$id": "http://localhost:1234/node",
                     "description": "node",
                     "type": "object",
                     "properties": {
-                        "value": {"type": "number"},
-                        "subtree": {"$ref": "tree"}
+                        "value": {
+                            "type": "number"
+                        },
+                        "subtree": {
+                            "$ref": "tree"
+                        }
                     },
-                    "required": ["value"]
+                    "required": [
+                        "value"
+                    ]
                 }
             }
         },
         "tests": [
             {
                 "description": "valid tree",
-                "data": { 
+                "data": {
                     "meta": "root",
                     "nodes": [
                         {
@@ -279,8 +376,12 @@
                             "subtree": {
                                 "meta": "child",
                                 "nodes": [
-                                    {"value": 1.1},
-                                    {"value": 1.2}
+                                    {
+                                        "value": 1.1
+                                    },
+                                    {
+                                        "value": 1.2
+                                    }
                                 ]
                             }
                         },
@@ -289,8 +390,12 @@
                             "subtree": {
                                 "meta": "child",
                                 "nodes": [
-                                    {"value": 2.1},
-                                    {"value": 2.2}
+                                    {
+                                        "value": 2.1
+                                    },
+                                    {
+                                        "value": 2.2
+                                    }
                                 ]
                             }
                         }
@@ -300,7 +405,7 @@
             },
             {
                 "description": "invalid tree",
-                "data": { 
+                "data": {
                     "meta": "root",
                     "nodes": [
                         {
@@ -308,8 +413,12 @@
                             "subtree": {
                                 "meta": "child",
                                 "nodes": [
-                                    {"value": "string is invalid"},
-                                    {"value": 1.2}
+                                    {
+                                        "value": "string is invalid"
+                                    },
+                                    {
+                                        "value": 1.2
+                                    }
                                 ]
                             }
                         },
@@ -318,8 +427,12 @@
                             "subtree": {
                                 "meta": "child",
                                 "nodes": [
-                                    {"value": 2.1},
-                                    {"value": 2.2}
+                                    {
+                                        "value": 2.1
+                                    },
+                                    {
+                                        "value": 2.2
+                                    }
                                 ]
                             }
                         }

--- a/tests/jsonschema/draft7/refRemote.json
+++ b/tests/jsonschema/draft7/refRemote.json
@@ -1,7 +1,9 @@
 [
     {
         "description": "remote ref",
-        "schema": {"$ref": "http://localhost:1234/integer.json"},
+        "schema": {
+            "$ref": "http://localhost:1234/integer.json"
+        },
         "tests": [
             {
                 "description": "remote ref valid",
@@ -17,7 +19,9 @@
     },
     {
         "description": "fragment within remote ref",
-        "schema": {"$ref": "http://localhost:1234/subSchemas.json#/integer"},
+        "schema": {
+            "$ref": "http://localhost:1234/subSchemas.json#/integer"
+        },
         "tests": [
             {
                 "description": "remote fragment valid",
@@ -55,18 +59,28 @@
             "$id": "http://localhost:1234/",
             "items": {
                 "$id": "folder/",
-                "items": {"$ref": "folderInteger.json"}
+                "items": {
+                    "$ref": "folderInteger.json"
+                }
             }
         },
         "tests": [
             {
                 "description": "base URI change ref valid",
-                "data": [[1]],
+                "data": [
+                    [
+                        1
+                    ]
+                ],
                 "valid": true
             },
             {
                 "description": "base URI change ref invalid",
-                "data": [["a"]],
+                "data": [
+                    [
+                        "a"
+                    ]
+                ],
                 "valid": false
             }
         ]
@@ -75,27 +89,39 @@
         "description": "base URI change - change folder",
         "schema": {
             "$id": "http://localhost:1234/scope_change_defs1.json",
-            "type" : "object",
+            "type": "object",
             "properties": {
-                "list": {"$ref": "#/definitions/baz"}
+                "list": {
+                    "$ref": "#/components/schemas/baz"
+                }
             },
-            "definitions": {
+            "components/schemas": {
                 "baz": {
                     "$id": "folder/",
                     "type": "array",
-                    "items": {"$ref": "folderInteger.json"}
+                    "items": {
+                        "$ref": "folderInteger.json"
+                    }
                 }
             }
         },
         "tests": [
             {
                 "description": "number is valid",
-                "data": {"list": [1]},
+                "data": {
+                    "list": [
+                        1
+                    ]
+                },
                 "valid": true
             },
             {
                 "description": "string is invalid",
-                "data": {"list": ["a"]},
+                "data": {
+                    "list": [
+                        "a"
+                    ]
+                },
                 "valid": false
             }
         ]
@@ -104,17 +130,21 @@
         "description": "base URI change - change folder in subschema",
         "schema": {
             "$id": "http://localhost:1234/scope_change_defs2.json",
-            "type" : "object",
+            "type": "object",
             "properties": {
-                "list": {"$ref": "#/definitions/baz/definitions/bar"}
+                "list": {
+                    "$ref": "#/components/schemas/baz/components/schemas/bar"
+                }
             },
-            "definitions": {
+            "components/schemas": {
                 "baz": {
                     "$id": "folder/",
-                    "definitions": {
+                    "components/schemas": {
                         "bar": {
                             "type": "array",
-                            "items": {"$ref": "folderInteger.json"}
+                            "items": {
+                                "$ref": "folderInteger.json"
+                            }
                         }
                     }
                 }
@@ -123,12 +153,20 @@
         "tests": [
             {
                 "description": "number is valid",
-                "data": {"list": [1]},
+                "data": {
+                    "list": [
+                        1
+                    ]
+                },
                 "valid": true
             },
             {
                 "description": "string is invalid",
-                "data": {"list": ["a"]},
+                "data": {
+                    "list": [
+                        "a"
+                    ]
+                },
                 "valid": false
             }
         ]
@@ -139,7 +177,9 @@
             "$id": "http://localhost:1234/object",
             "type": "object",
             "properties": {
-                "name": {"$ref": "name.json#/definitions/orNull"}
+                "name": {
+                    "$ref": "name.json#/components/schemas/orNull"
+                }
             }
         },
         "tests": [

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -454,13 +454,15 @@ def test_nested_schema_to_json_schema():
             "artist": {"$ref": "#/components/schemas/Artist"},
         },
         "required": ["title", "release_date", "artist"],
-        "definitions": {
-            "Artist": {
-                "type": "object",
-                "properties": {
-                    "name": {"type": "string", "minLength": 1, "maxLength": 100}
-                },
-                "required": ["name"],
+        "components": {
+            "schemas": {
+                "Artist": {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string", "minLength": 1, "maxLength": 100}
+                    },
+                    "required": ["name"],
+                }
             }
         },
     }
@@ -485,27 +487,29 @@ def test_definitions_to_json_schema():
     schema = typesystem.to_json_schema(definitions)
 
     assert schema == {
-        "definitions": {
-            "Artist": {
-                "type": "object",
-                "properties": {
-                    "name": {"type": "string", "minLength": 1, "maxLength": 100}
-                },
-                "required": ["name"],
-            },
-            "Album": {
-                "type": "object",
-                "properties": {
-                    "title": {"type": "string", "minLength": 1, "maxLength": 100},
-                    "release_date": {
-                        "type": "string",
-                        "minLength": 1,
-                        "format": "date",
+        "components": {
+            "schemas": {
+                "Artist": {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string", "minLength": 1, "maxLength": 100}
                     },
-                    "artist": {"$ref": "#/components/schemas/Artist"},
+                    "required": ["name"],
                 },
-                "required": ["title", "release_date", "artist"],
-            },
+                "Album": {
+                    "type": "object",
+                    "properties": {
+                        "title": {"type": "string", "minLength": 1, "maxLength": 100},
+                        "release_date": {
+                            "type": "string",
+                            "minLength": 1,
+                            "format": "date",
+                        },
+                        "artist": {"$ref": "#/components/schemas/Artist"},
+                    },
+                    "required": ["title", "release_date", "artist"],
+                },
+            }
         }
     }
 

--- a/typesystem/json_schema.py
+++ b/typesystem/json_schema.py
@@ -115,7 +115,7 @@ def from_json_schema(
 
     if definitions is None:
         definitions = Definitions()
-        for key, value in data.get("definitions", {}).items():
+        for key, value in data.get("components", {}).get("schemas", {}).items():
             ref = f"#/components/schemas/{key}"
             definitions[ref] = from_json_schema(value, definitions=definitions)
 
@@ -571,7 +571,8 @@ def to_json_schema(
         raise ValueError(f"Cannot convert field type {name!r} to JSON Schema")
 
     if is_root and definitions:
-        data["definitions"] = definitions
+        data["components"] = {}
+        data["components"]["schemas"] = definitions
     return data
 
 


### PR DESCRIPTION
Fixes #121.

In Version 0.4.0 references are made in `OAS 3` like: `"$ref": "#/components/schemas/Artist"`
But the definitions are still for OAS2.

I think now maybe `Definition` is not accurate anymore, since this will be more like `Schemas` now.
I'll try to change that, any feedback is appreciated.