### PR TITLE
fix wrong type annotation for properties parameter in Object type

### DIFF
--- a/typesystem/fields.py
+++ b/typesystem/fields.py
@@ -409,7 +409,7 @@ class Object(Field):
     def __init__(
         self,
         *,
-        properties: typing.Dict[str, Field] = None,
+        properties: typing.Union[Field, typing.Dict[str, Field]] = None,
         pattern_properties: typing.Dict[str, Field] = None,
         additional_properties: typing.Union[bool, None, Field] = True,
         property_names: Field = None,


### PR DESCRIPTION
Hi.
I found a subtle bug in the `__init__` parameters of Object type. 
Then i shared the bug at the community discussions
![Screenshot_20220707_064932](https://user-images.githubusercontent.com/96727989/177676074-520b079f-9214-4a8e-8803-cb2dc8be1069.png)
and i got the answer to make a pr.
After fixing the bug, I ran pytest through all the tests and they all passed.
Thanks